### PR TITLE
pytest path workaround

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -36,4 +36,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest tests/
+        python -m pytest tests/


### PR DESCRIPTION
Changing the pytest run command from `pytest tests/` to `python -m pytest tests/` fixes the import issues, so pytest works on Github. Locally, adding a `cities.pth` inside your virtualenv's `site-packages` folder lets you run `pytest tests/` with the same result.