### PR TITLE
allow for no outcome and null outcome weight

### DIFF
--- a/cities/utils/cleaning_utils.py
+++ b/cities/utils/cleaning_utils.py
@@ -1,5 +1,3 @@
-import os
-import re
 from pathlib import Path
 
 import numpy as np

--- a/cities/utils/similarity_utils.py
+++ b/cities/utils/similarity_utils.py
@@ -85,8 +85,13 @@ def divide_exponentially(group_weight, number_of_features, rate):
 
 def compute_weight_array(query_object, rate=1.08):
 
-    assert sum(abs(value) for key, value in query_object.feature_groups_with_weights.items()
-        ) != 0, "At least one weight has to be other than 0"
+    assert (
+        sum(
+            abs(value)
+            for key, value in query_object.feature_groups_with_weights.items()
+        )
+        != 0
+    ), "At least one weight has to be other than 0"
 
     max_other_scores = sum(
         abs(value)
@@ -94,7 +99,10 @@ def compute_weight_array(query_object, rate=1.08):
         if key != query_object.outcome_var
     )
 
-    if query_object.outcome_var and query_object.feature_groups_with_weights[query_object.outcome_var] != 0:
+    if (
+        query_object.outcome_var
+        and query_object.feature_groups_with_weights[query_object.outcome_var] != 0
+    ):
         weight_outcome_joint = max_other_scores if max_other_scores > 0 else 1
         query_object.feature_groups_with_weights[query_object.outcome_var] = (
             weight_outcome_joint

--- a/docs/guides/similarity_demo.ipynb
+++ b/docs/guides/similarity_demo.ipynb
@@ -24,14 +24,938 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['population', 'spending_commerce', 'transport', 'spending_transportation', 'urbanization', 'spending_HHS', 'industry', 'gdp', 'ethnic_composition']\n"
+      "['spending_commerce', 'transport', 'spending_transportation', 'spending_HHS', 'ethnic_composition', 'gdp', 'urbanization', 'industry', 'population']\n"
      ]
     },
     {
      "data": {
-      "text/plain": [
-       "(1, 12)"
-      ]
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "type": "bar",
+         "x": [
+          "1993_population",
+          "1994_population",
+          "1995_population",
+          "1996_population",
+          "1997_population",
+          "1998_population",
+          "1999_population",
+          "2000_population",
+          "2001_population",
+          "2002_population",
+          "2003_population",
+          "2004_population",
+          "2005_population",
+          "2006_population",
+          "2007_population",
+          "2008_population",
+          "2009_population",
+          "2010_population",
+          "2011_population",
+          "2012_population",
+          "2013_population",
+          "2014_population",
+          "2015_population",
+          "2016_population",
+          "2017_population",
+          "2018_population",
+          "2019_population",
+          "2020_population",
+          "2021_population",
+          "2010_spending_HHS",
+          "2011_spending_HHS",
+          "2012_spending_HHS",
+          "2013_spending_HHS",
+          "2014_spending_HHS",
+          "2015_spending_HHS",
+          "2016_spending_HHS",
+          "2017_spending_HHS",
+          "2018_spending_HHS",
+          "2019_spending_HHS",
+          "2020_spending_HHS",
+          "2021_spending_HHS"
+         ],
+         "y": [
+          0.03847414014225456,
+          0.04155207135363493,
+          0.04487623706192573,
+          0.04846633602687978,
+          0.05234364290903017,
+          0.056531134341752595,
+          0.0610536250890928,
+          0.06593791509622024,
+          0.07121294830391786,
+          0.07690998416823129,
+          0.08306278290168981,
+          0.08970780553382499,
+          0.09688442997653099,
+          0.10463518437465348,
+          0.11300599912462576,
+          0.12204647905459583,
+          0.13181019737896352,
+          0.14235501316928062,
+          0.15374341422282306,
+          0.1660428873606489,
+          0.17932631834950083,
+          0.19367242381746091,
+          0.20916621772285782,
+          0.22589951514068643,
+          0.24397147635194139,
+          0.2634891944600967,
+          0.28456833001690446,
+          0.30733379641825687,
+          0.3319205001317174,
+          0.15808505077340862,
+          0.17073185483528133,
+          0.18439040322210384,
+          0.19914163547987215,
+          0.21507296631826195,
+          0.23227880362372297,
+          0.25086110791362076,
+          0.27092999654671046,
+          0.2926043962704473,
+          0.3160127479720831,
+          0.3412937678098498,
+          0.3685972692346378
+         ]
+        }
+       ],
+       "layout": {
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Weights of columns"
+        },
+        "xaxis": {
+         "title": {
+          "text": "columns"
+         }
+        },
+        "yaxis": {
+         "title": {
+          "text": "weights"
+         }
+        }
+       }
+      }
      },
      "metadata": {},
      "output_type": "display_data"
@@ -39,11 +963,3156 @@
     {
      "data": {
       "text/plain": [
-       "(3081, 12)"
+       "None"
       ]
      },
      "metadata": {},
      "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>1993_population</th>\n",
+       "      <th>1994_population</th>\n",
+       "      <th>1995_population</th>\n",
+       "      <th>1996_population</th>\n",
+       "      <th>1997_population</th>\n",
+       "      <th>1998_population</th>\n",
+       "      <th>1999_population</th>\n",
+       "      <th>2000_population</th>\n",
+       "      <th>2001_population</th>\n",
+       "      <th>2002_population</th>\n",
+       "      <th>...</th>\n",
+       "      <th>2013_spending_HHS</th>\n",
+       "      <th>2014_spending_HHS</th>\n",
+       "      <th>2015_spending_HHS</th>\n",
+       "      <th>2016_spending_HHS</th>\n",
+       "      <th>2017_spending_HHS</th>\n",
+       "      <th>2018_spending_HHS</th>\n",
+       "      <th>2019_spending_HHS</th>\n",
+       "      <th>2020_spending_HHS</th>\n",
+       "      <th>2021_spending_HHS</th>\n",
+       "      <th>distance to 42001</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2235</th>\n",
+       "      <td>83013.0</td>\n",
+       "      <td>84186.0</td>\n",
+       "      <td>85063.0</td>\n",
+       "      <td>86252.0</td>\n",
+       "      <td>87751.0</td>\n",
+       "      <td>89074.0</td>\n",
+       "      <td>90363.0</td>\n",
+       "      <td>91457.0</td>\n",
+       "      <td>92591.0</td>\n",
+       "      <td>93934.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6.841459e+07</td>\n",
+       "      <td>2.843109e+07</td>\n",
+       "      <td>1.022756e+07</td>\n",
+       "      <td>3.068268e+07</td>\n",
+       "      <td>2.081153e+07</td>\n",
+       "      <td>3.134013e+07</td>\n",
+       "      <td>5.207267e+07</td>\n",
+       "      <td>3.151378e+07</td>\n",
+       "      <td>4.473508e+07</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3006</th>\n",
+       "      <td>92876.0</td>\n",
+       "      <td>93717.0</td>\n",
+       "      <td>94509.0</td>\n",
+       "      <td>95529.0</td>\n",
+       "      <td>95998.0</td>\n",
+       "      <td>96512.0</td>\n",
+       "      <td>96985.0</td>\n",
+       "      <td>97390.0</td>\n",
+       "      <td>97856.0</td>\n",
+       "      <td>98097.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.548639e+07</td>\n",
+       "      <td>3.562433e+07</td>\n",
+       "      <td>2.471649e+07</td>\n",
+       "      <td>3.263073e+07</td>\n",
+       "      <td>5.403922e+07</td>\n",
+       "      <td>4.703442e+07</td>\n",
+       "      <td>5.464052e+07</td>\n",
+       "      <td>5.844357e+07</td>\n",
+       "      <td>7.377923e+07</td>\n",
+       "      <td>0.026253</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1244</th>\n",
+       "      <td>96534.0</td>\n",
+       "      <td>97920.0</td>\n",
+       "      <td>99350.0</td>\n",
+       "      <td>100660.0</td>\n",
+       "      <td>101474.0</td>\n",
+       "      <td>102280.0</td>\n",
+       "      <td>102991.0</td>\n",
+       "      <td>104000.0</td>\n",
+       "      <td>104848.0</td>\n",
+       "      <td>105794.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>5.135486e+07</td>\n",
+       "      <td>1.685584e+07</td>\n",
+       "      <td>2.075568e+07</td>\n",
+       "      <td>6.394366e+07</td>\n",
+       "      <td>2.995285e+07</td>\n",
+       "      <td>6.536969e+07</td>\n",
+       "      <td>5.782530e+07</td>\n",
+       "      <td>6.692654e+07</td>\n",
+       "      <td>4.542509e+07</td>\n",
+       "      <td>0.030965</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>116324.0</td>\n",
+       "      <td>116161.0</td>\n",
+       "      <td>116790.0</td>\n",
+       "      <td>116684.0</td>\n",
+       "      <td>117254.0</td>\n",
+       "      <td>117179.0</td>\n",
+       "      <td>114910.0</td>\n",
+       "      <td>111081.0</td>\n",
+       "      <td>111266.0</td>\n",
+       "      <td>111625.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>3.943803e+07</td>\n",
+       "      <td>4.531137e+07</td>\n",
+       "      <td>3.266888e+07</td>\n",
+       "      <td>3.188817e+07</td>\n",
+       "      <td>3.195046e+07</td>\n",
+       "      <td>4.203667e+07</td>\n",
+       "      <td>2.714948e+07</td>\n",
+       "      <td>2.231390e+07</td>\n",
+       "      <td>2.433614e+07</td>\n",
+       "      <td>0.033050</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1853</th>\n",
+       "      <td>98327.0</td>\n",
+       "      <td>98509.0</td>\n",
+       "      <td>98816.0</td>\n",
+       "      <td>99509.0</td>\n",
+       "      <td>99693.0</td>\n",
+       "      <td>99603.0</td>\n",
+       "      <td>99802.0</td>\n",
+       "      <td>100106.0</td>\n",
+       "      <td>100819.0</td>\n",
+       "      <td>101763.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.743605e+07</td>\n",
+       "      <td>1.820944e+07</td>\n",
+       "      <td>7.596719e+06</td>\n",
+       "      <td>1.534277e+07</td>\n",
+       "      <td>5.635192e+07</td>\n",
+       "      <td>2.467059e+07</td>\n",
+       "      <td>1.403323e+07</td>\n",
+       "      <td>4.650258e+07</td>\n",
+       "      <td>4.890882e+07</td>\n",
+       "      <td>0.034477</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2384</th>\n",
+       "      <td>15660.0</td>\n",
+       "      <td>15902.0</td>\n",
+       "      <td>15997.0</td>\n",
+       "      <td>16082.0</td>\n",
+       "      <td>16053.0</td>\n",
+       "      <td>16129.0</td>\n",
+       "      <td>16386.0</td>\n",
+       "      <td>16505.0</td>\n",
+       "      <td>16351.0</td>\n",
+       "      <td>16479.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>4.016453e+09</td>\n",
+       "      <td>3.975215e+09</td>\n",
+       "      <td>4.085792e+09</td>\n",
+       "      <td>3.715688e+09</td>\n",
+       "      <td>6.654582e+09</td>\n",
+       "      <td>7.660348e+09</td>\n",
+       "      <td>1.127461e+10</td>\n",
+       "      <td>1.530217e+10</td>\n",
+       "      <td>1.712052e+10</td>\n",
+       "      <td>2.369198</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2740</th>\n",
+       "      <td>649226.0</td>\n",
+       "      <td>671759.0</td>\n",
+       "      <td>696278.0</td>\n",
+       "      <td>717194.0</td>\n",
+       "      <td>736587.0</td>\n",
+       "      <td>761335.0</td>\n",
+       "      <td>788500.0</td>\n",
+       "      <td>819692.0</td>\n",
+       "      <td>844877.0</td>\n",
+       "      <td>848090.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.225282e+11</td>\n",
+       "      <td>2.231797e+11</td>\n",
+       "      <td>2.118196e+11</td>\n",
+       "      <td>2.138400e+11</td>\n",
+       "      <td>2.527288e+11</td>\n",
+       "      <td>3.552319e+11</td>\n",
+       "      <td>4.896949e+11</td>\n",
+       "      <td>6.288495e+11</td>\n",
+       "      <td>7.776532e+11</td>\n",
+       "      <td>2.469107</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>198</th>\n",
+       "      <td>9100159.0</td>\n",
+       "      <td>9096608.0</td>\n",
+       "      <td>9089015.0</td>\n",
+       "      <td>9127042.0</td>\n",
+       "      <td>9206538.0</td>\n",
+       "      <td>9313589.0</td>\n",
+       "      <td>9437290.0</td>\n",
+       "      <td>9538191.0</td>\n",
+       "      <td>9626034.0</td>\n",
+       "      <td>9705913.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.348763e+10</td>\n",
+       "      <td>2.294435e+10</td>\n",
+       "      <td>2.502567e+10</td>\n",
+       "      <td>2.839330e+10</td>\n",
+       "      <td>3.868660e+10</td>\n",
+       "      <td>5.899629e+10</td>\n",
+       "      <td>1.410259e+11</td>\n",
+       "      <td>2.187211e+11</td>\n",
+       "      <td>2.577860e+11</td>\n",
+       "      <td>2.725159</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1819</th>\n",
+       "      <td>298592.0</td>\n",
+       "      <td>300262.0</td>\n",
+       "      <td>299725.0</td>\n",
+       "      <td>297680.0</td>\n",
+       "      <td>296187.0</td>\n",
+       "      <td>295097.0</td>\n",
+       "      <td>294692.0</td>\n",
+       "      <td>295106.0</td>\n",
+       "      <td>296232.0</td>\n",
+       "      <td>298283.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>3.271360e+11</td>\n",
+       "      <td>3.134117e+11</td>\n",
+       "      <td>3.894925e+11</td>\n",
+       "      <td>3.271486e+11</td>\n",
+       "      <td>7.462131e+11</td>\n",
+       "      <td>6.579396e+11</td>\n",
+       "      <td>8.941410e+11</td>\n",
+       "      <td>9.732370e+11</td>\n",
+       "      <td>9.351828e+11</td>\n",
+       "      <td>2.941499</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>213</th>\n",
+       "      <td>1127608.0</td>\n",
+       "      <td>1130094.0</td>\n",
+       "      <td>1140825.0</td>\n",
+       "      <td>1155635.0</td>\n",
+       "      <td>1169855.0</td>\n",
+       "      <td>1186617.0</td>\n",
+       "      <td>1206659.0</td>\n",
+       "      <td>1229940.0</td>\n",
+       "      <td>1266257.0</td>\n",
+       "      <td>1301079.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>3.614194e+11</td>\n",
+       "      <td>4.741250e+11</td>\n",
+       "      <td>3.639794e+11</td>\n",
+       "      <td>3.878961e+11</td>\n",
+       "      <td>3.388018e+11</td>\n",
+       "      <td>1.298456e+12</td>\n",
+       "      <td>1.235765e+12</td>\n",
+       "      <td>1.717218e+12</td>\n",
+       "      <td>1.842294e+12</td>\n",
+       "      <td>3.359044</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>3082 rows × 42 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      1993_population  1994_population  1995_population  1996_population  \\\n",
+       "2235          83013.0          84186.0          85063.0          86252.0   \n",
+       "3006          92876.0          93717.0          94509.0          95529.0   \n",
+       "1244          96534.0          97920.0          99350.0         100660.0   \n",
+       "7            116324.0         116161.0         116790.0         116684.0   \n",
+       "1853          98327.0          98509.0          98816.0          99509.0   \n",
+       "...               ...              ...              ...              ...   \n",
+       "2384          15660.0          15902.0          15997.0          16082.0   \n",
+       "2740         649226.0         671759.0         696278.0         717194.0   \n",
+       "198         9100159.0        9096608.0        9089015.0        9127042.0   \n",
+       "1819         298592.0         300262.0         299725.0         297680.0   \n",
+       "213         1127608.0        1130094.0        1140825.0        1155635.0   \n",
+       "\n",
+       "      1997_population  1998_population  1999_population  2000_population  \\\n",
+       "2235          87751.0          89074.0          90363.0          91457.0   \n",
+       "3006          95998.0          96512.0          96985.0          97390.0   \n",
+       "1244         101474.0         102280.0         102991.0         104000.0   \n",
+       "7            117254.0         117179.0         114910.0         111081.0   \n",
+       "1853          99693.0          99603.0          99802.0         100106.0   \n",
+       "...               ...              ...              ...              ...   \n",
+       "2384          16053.0          16129.0          16386.0          16505.0   \n",
+       "2740         736587.0         761335.0         788500.0         819692.0   \n",
+       "198         9206538.0        9313589.0        9437290.0        9538191.0   \n",
+       "1819         296187.0         295097.0         294692.0         295106.0   \n",
+       "213         1169855.0        1186617.0        1206659.0        1229940.0   \n",
+       "\n",
+       "      2001_population  2002_population  ...  2013_spending_HHS  \\\n",
+       "2235          92591.0          93934.0  ...       6.841459e+07   \n",
+       "3006          97856.0          98097.0  ...       2.548639e+07   \n",
+       "1244         104848.0         105794.0  ...       5.135486e+07   \n",
+       "7            111266.0         111625.0  ...       3.943803e+07   \n",
+       "1853         100819.0         101763.0  ...       2.743605e+07   \n",
+       "...               ...              ...  ...                ...   \n",
+       "2384          16351.0          16479.0  ...       4.016453e+09   \n",
+       "2740         844877.0         848090.0  ...       2.225282e+11   \n",
+       "198         9626034.0        9705913.0  ...       2.348763e+10   \n",
+       "1819         296232.0         298283.0  ...       3.271360e+11   \n",
+       "213         1266257.0        1301079.0  ...       3.614194e+11   \n",
+       "\n",
+       "      2014_spending_HHS  2015_spending_HHS  2016_spending_HHS  \\\n",
+       "2235       2.843109e+07       1.022756e+07       3.068268e+07   \n",
+       "3006       3.562433e+07       2.471649e+07       3.263073e+07   \n",
+       "1244       1.685584e+07       2.075568e+07       6.394366e+07   \n",
+       "7          4.531137e+07       3.266888e+07       3.188817e+07   \n",
+       "1853       1.820944e+07       7.596719e+06       1.534277e+07   \n",
+       "...                 ...                ...                ...   \n",
+       "2384       3.975215e+09       4.085792e+09       3.715688e+09   \n",
+       "2740       2.231797e+11       2.118196e+11       2.138400e+11   \n",
+       "198        2.294435e+10       2.502567e+10       2.839330e+10   \n",
+       "1819       3.134117e+11       3.894925e+11       3.271486e+11   \n",
+       "213        4.741250e+11       3.639794e+11       3.878961e+11   \n",
+       "\n",
+       "      2017_spending_HHS  2018_spending_HHS  2019_spending_HHS  \\\n",
+       "2235       2.081153e+07       3.134013e+07       5.207267e+07   \n",
+       "3006       5.403922e+07       4.703442e+07       5.464052e+07   \n",
+       "1244       2.995285e+07       6.536969e+07       5.782530e+07   \n",
+       "7          3.195046e+07       4.203667e+07       2.714948e+07   \n",
+       "1853       5.635192e+07       2.467059e+07       1.403323e+07   \n",
+       "...                 ...                ...                ...   \n",
+       "2384       6.654582e+09       7.660348e+09       1.127461e+10   \n",
+       "2740       2.527288e+11       3.552319e+11       4.896949e+11   \n",
+       "198        3.868660e+10       5.899629e+10       1.410259e+11   \n",
+       "1819       7.462131e+11       6.579396e+11       8.941410e+11   \n",
+       "213        3.388018e+11       1.298456e+12       1.235765e+12   \n",
+       "\n",
+       "      2020_spending_HHS  2021_spending_HHS  distance to 42001  \n",
+       "2235       3.151378e+07       4.473508e+07           0.000000  \n",
+       "3006       5.844357e+07       7.377923e+07           0.026253  \n",
+       "1244       6.692654e+07       4.542509e+07           0.030965  \n",
+       "7          2.231390e+07       2.433614e+07           0.033050  \n",
+       "1853       4.650258e+07       4.890882e+07           0.034477  \n",
+       "...                 ...                ...                ...  \n",
+       "2384       1.530217e+10       1.712052e+10           2.369198  \n",
+       "2740       6.288495e+11       7.776532e+11           2.469107  \n",
+       "198        2.187211e+11       2.577860e+11           2.725159  \n",
+       "1819       9.732370e+11       9.351828e+11           2.941499  \n",
+       "213        1.717218e+12       1.842294e+12           3.359044  \n",
+       "\n",
+       "[3082 rows x 42 columns]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# You don't want to pass outcome and are interested in similarities\n",
+    "print(list_available_features())\n",
+    "f  = FipsQuery(42001, feature_groups_with_weights= {\"population\":4, \"spending_HHS\": 3})\n",
+    "f.find_euclidean_kins()\n",
+    "display(f.plot_weights())\n",
+    "display(f.euclidean_kins)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['spending_commerce', 'transport', 'spending_transportation', 'spending_HHS', 'ethnic_composition', 'gdp', 'urbanization', 'industry', 'population']\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "type": "bar",
+         "x": [
+          "2010_spending_HHS",
+          "2011_spending_HHS",
+          "2012_spending_HHS",
+          "2013_spending_HHS",
+          "2014_spending_HHS",
+          "2015_spending_HHS",
+          "2016_spending_HHS",
+          "2017_spending_HHS",
+          "2018_spending_HHS",
+          "2019_spending_HHS",
+          "2020_spending_HHS",
+          "2021_spending_HHS",
+          "1993_population",
+          "1994_population",
+          "1995_population",
+          "1996_population",
+          "1997_population",
+          "1998_population",
+          "1999_population",
+          "2000_population",
+          "2001_population",
+          "2002_population",
+          "2003_population",
+          "2004_population",
+          "2005_population",
+          "2006_population",
+          "2007_population",
+          "2008_population",
+          "2009_population",
+          "2010_population",
+          "2011_population",
+          "2012_population",
+          "2013_population",
+          "2014_population",
+          "2015_population",
+          "2016_population",
+          "2017_population",
+          "2018_population",
+          "2019_population",
+          "2020_population",
+          "2021_population"
+         ],
+         "y": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0.03847414014225456,
+          0.04155207135363493,
+          0.04487623706192573,
+          0.04846633602687978,
+          0.05234364290903017,
+          0.056531134341752595,
+          0.0610536250890928,
+          0.06593791509622024,
+          0.07121294830391786,
+          0.07690998416823129,
+          0.08306278290168981,
+          0.08970780553382499,
+          0.09688442997653099,
+          0.10463518437465348,
+          0.11300599912462576,
+          0.12204647905459583,
+          0.13181019737896352,
+          0.14235501316928062,
+          0.15374341422282306,
+          0.1660428873606489,
+          0.17932631834950083,
+          0.19367242381746091,
+          0.20916621772285782,
+          0.22589951514068643,
+          0.24397147635194139,
+          0.2634891944600967,
+          0.28456833001690446,
+          0.30733379641825687,
+          0.3319205001317174
+         ]
+        }
+       ],
+       "layout": {
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Weights of columns"
+        },
+        "xaxis": {
+         "title": {
+          "text": "columns"
+         }
+        },
+        "yaxis": {
+         "title": {
+          "text": "weights"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "None"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>GeoFIPS</th>\n",
+       "      <th>GeoName</th>\n",
+       "      <th>2010</th>\n",
+       "      <th>2011</th>\n",
+       "      <th>2012</th>\n",
+       "      <th>2013</th>\n",
+       "      <th>2014</th>\n",
+       "      <th>2015</th>\n",
+       "      <th>2016</th>\n",
+       "      <th>2017</th>\n",
+       "      <th>...</th>\n",
+       "      <th>2014_population</th>\n",
+       "      <th>2015_population</th>\n",
+       "      <th>2016_population</th>\n",
+       "      <th>2017_population</th>\n",
+       "      <th>2018_population</th>\n",
+       "      <th>2019_population</th>\n",
+       "      <th>2020_population</th>\n",
+       "      <th>2021_population</th>\n",
+       "      <th>distance to 42001</th>\n",
+       "      <th>percentile</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>42001</td>\n",
+       "      <td>Adams, PA</td>\n",
+       "      <td>2.771827e+07</td>\n",
+       "      <td>2.855134e+07</td>\n",
+       "      <td>1.427164e+07</td>\n",
+       "      <td>6.841459e+07</td>\n",
+       "      <td>2.843109e+07</td>\n",
+       "      <td>1.022756e+07</td>\n",
+       "      <td>3.068268e+07</td>\n",
+       "      <td>2.081153e+07</td>\n",
+       "      <td>...</td>\n",
+       "      <td>101830.0</td>\n",
+       "      <td>102411.0</td>\n",
+       "      <td>102625.0</td>\n",
+       "      <td>103414.0</td>\n",
+       "      <td>103932.0</td>\n",
+       "      <td>103778.0</td>\n",
+       "      <td>103795.0</td>\n",
+       "      <td>104127.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>63.85</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>55039</td>\n",
+       "      <td>Fond du Lac, WI</td>\n",
+       "      <td>3.610418e+07</td>\n",
+       "      <td>2.696325e+07</td>\n",
+       "      <td>3.833402e+07</td>\n",
+       "      <td>2.548639e+07</td>\n",
+       "      <td>3.562433e+07</td>\n",
+       "      <td>2.471649e+07</td>\n",
+       "      <td>3.263073e+07</td>\n",
+       "      <td>5.403922e+07</td>\n",
+       "      <td>...</td>\n",
+       "      <td>102495.0</td>\n",
+       "      <td>102590.0</td>\n",
+       "      <td>102927.0</td>\n",
+       "      <td>103180.0</td>\n",
+       "      <td>103754.0</td>\n",
+       "      <td>104175.0</td>\n",
+       "      <td>104076.0</td>\n",
+       "      <td>104362.0</td>\n",
+       "      <td>0.004093</td>\n",
+       "      <td>69.34</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>29071</td>\n",
+       "      <td>Franklin, MO</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>...</td>\n",
+       "      <td>102058.0</td>\n",
+       "      <td>102429.0</td>\n",
+       "      <td>102952.0</td>\n",
+       "      <td>103563.0</td>\n",
+       "      <td>103967.0</td>\n",
+       "      <td>104137.0</td>\n",
+       "      <td>104769.0</td>\n",
+       "      <td>105231.0</td>\n",
+       "      <td>0.008424</td>\n",
+       "      <td>44.71</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1055</td>\n",
+       "      <td>Etowah, AL</td>\n",
+       "      <td>1.649418e+08</td>\n",
+       "      <td>1.154164e+09</td>\n",
+       "      <td>2.897688e+08</td>\n",
+       "      <td>1.134255e+09</td>\n",
+       "      <td>6.389997e+08</td>\n",
+       "      <td>8.881343e+08</td>\n",
+       "      <td>1.031911e+09</td>\n",
+       "      <td>9.080343e+08</td>\n",
+       "      <td>...</td>\n",
+       "      <td>103880.0</td>\n",
+       "      <td>103601.0</td>\n",
+       "      <td>103603.0</td>\n",
+       "      <td>103854.0</td>\n",
+       "      <td>103646.0</td>\n",
+       "      <td>103440.0</td>\n",
+       "      <td>103393.0</td>\n",
+       "      <td>103162.0</td>\n",
+       "      <td>0.008731</td>\n",
+       "      <td>90.56</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>26017</td>\n",
+       "      <td>Bay, MI</td>\n",
+       "      <td>2.073759e+06</td>\n",
+       "      <td>1.232872e+06</td>\n",
+       "      <td>5.381210e+05</td>\n",
+       "      <td>8.434320e+05</td>\n",
+       "      <td>1.047389e+06</td>\n",
+       "      <td>1.047389e+06</td>\n",
+       "      <td>2.580589e+06</td>\n",
+       "      <td>4.565004e+06</td>\n",
+       "      <td>...</td>\n",
+       "      <td>106599.0</td>\n",
+       "      <td>105916.0</td>\n",
+       "      <td>105184.0</td>\n",
+       "      <td>104967.0</td>\n",
+       "      <td>104674.0</td>\n",
+       "      <td>104079.0</td>\n",
+       "      <td>103594.0</td>\n",
+       "      <td>102985.0</td>\n",
+       "      <td>0.011795</td>\n",
+       "      <td>52.34</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3077</th>\n",
+       "      <td>31005</td>\n",
+       "      <td>Arthur, NE</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>...</td>\n",
+       "      <td>437.0</td>\n",
+       "      <td>433.0</td>\n",
+       "      <td>445.0</td>\n",
+       "      <td>432.0</td>\n",
+       "      <td>435.0</td>\n",
+       "      <td>436.0</td>\n",
+       "      <td>431.0</td>\n",
+       "      <td>439.0</td>\n",
+       "      <td>1.977809</td>\n",
+       "      <td>0.00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3078</th>\n",
+       "      <td>48261</td>\n",
+       "      <td>Kenedy, TX</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>...</td>\n",
+       "      <td>421.0</td>\n",
+       "      <td>421.0</td>\n",
+       "      <td>404.0</td>\n",
+       "      <td>383.0</td>\n",
+       "      <td>389.0</td>\n",
+       "      <td>355.0</td>\n",
+       "      <td>346.0</td>\n",
+       "      <td>340.0</td>\n",
+       "      <td>1.978614</td>\n",
+       "      <td>0.00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3079</th>\n",
+       "      <td>48269</td>\n",
+       "      <td>King, TX</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>...</td>\n",
+       "      <td>257.0</td>\n",
+       "      <td>273.0</td>\n",
+       "      <td>281.0</td>\n",
+       "      <td>278.0</td>\n",
+       "      <td>265.0</td>\n",
+       "      <td>256.0</td>\n",
+       "      <td>270.0</td>\n",
+       "      <td>258.0</td>\n",
+       "      <td>1.980969</td>\n",
+       "      <td>0.00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3080</th>\n",
+       "      <td>48301</td>\n",
+       "      <td>Loving, TX</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>...</td>\n",
+       "      <td>59.0</td>\n",
+       "      <td>72.0</td>\n",
+       "      <td>64.0</td>\n",
+       "      <td>66.0</td>\n",
+       "      <td>67.0</td>\n",
+       "      <td>67.0</td>\n",
+       "      <td>67.0</td>\n",
+       "      <td>57.0</td>\n",
+       "      <td>1.985240</td>\n",
+       "      <td>0.00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3081</th>\n",
+       "      <td>6037</td>\n",
+       "      <td>Los Angeles, CA</td>\n",
+       "      <td>1.842950e+10</td>\n",
+       "      <td>2.759321e+10</td>\n",
+       "      <td>2.170315e+10</td>\n",
+       "      <td>2.348763e+10</td>\n",
+       "      <td>2.294435e+10</td>\n",
+       "      <td>2.502567e+10</td>\n",
+       "      <td>2.839330e+10</td>\n",
+       "      <td>3.868660e+10</td>\n",
+       "      <td>...</td>\n",
+       "      <td>10051511.0</td>\n",
+       "      <td>10099677.0</td>\n",
+       "      <td>10121673.0</td>\n",
+       "      <td>10123521.0</td>\n",
+       "      <td>10096986.0</td>\n",
+       "      <td>10051154.0</td>\n",
+       "      <td>9989165.0</td>\n",
+       "      <td>9829544.0</td>\n",
+       "      <td>2.014902</td>\n",
+       "      <td>99.64</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>3082 rows × 45 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      GeoFIPS          GeoName          2010          2011          2012  \\\n",
+       "0       42001        Adams, PA  2.771827e+07  2.855134e+07  1.427164e+07   \n",
+       "1       55039  Fond du Lac, WI  3.610418e+07  2.696325e+07  3.833402e+07   \n",
+       "2       29071     Franklin, MO  0.000000e+00  0.000000e+00  0.000000e+00   \n",
+       "3        1055       Etowah, AL  1.649418e+08  1.154164e+09  2.897688e+08   \n",
+       "4       26017          Bay, MI  2.073759e+06  1.232872e+06  5.381210e+05   \n",
+       "...       ...              ...           ...           ...           ...   \n",
+       "3077    31005       Arthur, NE  0.000000e+00  0.000000e+00  0.000000e+00   \n",
+       "3078    48261       Kenedy, TX  0.000000e+00  0.000000e+00  0.000000e+00   \n",
+       "3079    48269         King, TX  0.000000e+00  0.000000e+00  0.000000e+00   \n",
+       "3080    48301       Loving, TX  0.000000e+00  0.000000e+00  0.000000e+00   \n",
+       "3081     6037  Los Angeles, CA  1.842950e+10  2.759321e+10  2.170315e+10   \n",
+       "\n",
+       "              2013          2014          2015          2016          2017  \\\n",
+       "0     6.841459e+07  2.843109e+07  1.022756e+07  3.068268e+07  2.081153e+07   \n",
+       "1     2.548639e+07  3.562433e+07  2.471649e+07  3.263073e+07  5.403922e+07   \n",
+       "2     0.000000e+00  0.000000e+00  0.000000e+00  0.000000e+00  0.000000e+00   \n",
+       "3     1.134255e+09  6.389997e+08  8.881343e+08  1.031911e+09  9.080343e+08   \n",
+       "4     8.434320e+05  1.047389e+06  1.047389e+06  2.580589e+06  4.565004e+06   \n",
+       "...            ...           ...           ...           ...           ...   \n",
+       "3077  0.000000e+00  0.000000e+00  0.000000e+00  0.000000e+00  0.000000e+00   \n",
+       "3078  0.000000e+00  0.000000e+00  0.000000e+00  0.000000e+00  0.000000e+00   \n",
+       "3079  0.000000e+00  0.000000e+00  0.000000e+00  0.000000e+00  0.000000e+00   \n",
+       "3080  0.000000e+00  0.000000e+00  0.000000e+00  0.000000e+00  0.000000e+00   \n",
+       "3081  2.348763e+10  2.294435e+10  2.502567e+10  2.839330e+10  3.868660e+10   \n",
+       "\n",
+       "      ...  2014_population  2015_population  2016_population  2017_population  \\\n",
+       "0     ...         101830.0         102411.0         102625.0         103414.0   \n",
+       "1     ...         102495.0         102590.0         102927.0         103180.0   \n",
+       "2     ...         102058.0         102429.0         102952.0         103563.0   \n",
+       "3     ...         103880.0         103601.0         103603.0         103854.0   \n",
+       "4     ...         106599.0         105916.0         105184.0         104967.0   \n",
+       "...   ...              ...              ...              ...              ...   \n",
+       "3077  ...            437.0            433.0            445.0            432.0   \n",
+       "3078  ...            421.0            421.0            404.0            383.0   \n",
+       "3079  ...            257.0            273.0            281.0            278.0   \n",
+       "3080  ...             59.0             72.0             64.0             66.0   \n",
+       "3081  ...       10051511.0       10099677.0       10121673.0       10123521.0   \n",
+       "\n",
+       "      2018_population  2019_population  2020_population  2021_population  \\\n",
+       "0            103932.0         103778.0         103795.0         104127.0   \n",
+       "1            103754.0         104175.0         104076.0         104362.0   \n",
+       "2            103967.0         104137.0         104769.0         105231.0   \n",
+       "3            103646.0         103440.0         103393.0         103162.0   \n",
+       "4            104674.0         104079.0         103594.0         102985.0   \n",
+       "...               ...              ...              ...              ...   \n",
+       "3077            435.0            436.0            431.0            439.0   \n",
+       "3078            389.0            355.0            346.0            340.0   \n",
+       "3079            265.0            256.0            270.0            258.0   \n",
+       "3080             67.0             67.0             67.0             57.0   \n",
+       "3081       10096986.0       10051154.0        9989165.0        9829544.0   \n",
+       "\n",
+       "      distance to 42001  percentile  \n",
+       "0              0.000000       63.85  \n",
+       "1              0.004093       69.34  \n",
+       "2              0.008424       44.71  \n",
+       "3              0.008731       90.56  \n",
+       "4              0.011795       52.34  \n",
+       "...                 ...         ...  \n",
+       "3077           1.977809        0.00  \n",
+       "3078           1.978614        0.00  \n",
+       "3079           1.980969        0.00  \n",
+       "3080           1.985240        0.00  \n",
+       "3081           2.014902       99.64  \n",
+       "\n",
+       "[3082 rows x 45 columns]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# you want to pass an outcome but give it weight 0 in similarity calculations\n",
+    "\n",
+    "print(list_available_features())\n",
+    "f  = FipsQuery(42001, outcome_var = \"spending_HHS\", feature_groups_with_weights= {\"spending_HHS\": 0, \"population\":4})\n",
+    "f.find_euclidean_kins()\n",
+    "display(f.plot_weights())\n",
+    "display(f.euclidean_kins)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "type": "bar",
+         "x": [
+          "2001_gdp",
+          "2002_gdp",
+          "2003_gdp",
+          "2004_gdp",
+          "2005_gdp",
+          "2006_gdp",
+          "2007_gdp",
+          "2008_gdp",
+          "2009_gdp",
+          "2010_gdp",
+          "2011_gdp",
+          "2013_gdp",
+          "2014_gdp",
+          "2015_gdp",
+          "2016_gdp",
+          "2017_gdp",
+          "2018_gdp",
+          "2019_gdp",
+          "2020_gdp",
+          "2021_gdp",
+          "1993_population",
+          "1994_population",
+          "1995_population",
+          "1996_population",
+          "1997_population",
+          "1998_population",
+          "1999_population",
+          "2000_population",
+          "2001_population",
+          "2002_population",
+          "2003_population",
+          "2004_population",
+          "2005_population",
+          "2006_population",
+          "2007_population",
+          "2008_population",
+          "2009_population",
+          "2010_population",
+          "2011_population",
+          "2012_population",
+          "2013_population",
+          "2014_population",
+          "2015_population",
+          "2016_population",
+          "2017_population",
+          "2018_population",
+          "2019_population",
+          "2020_population",
+          "2021_population"
+         ],
+         "y": [
+          -0.07443141519371825,
+          -0.07666435764952981,
+          -0.07896428837901569,
+          -0.08133321703038617,
+          -0.08377321354129776,
+          -0.08628640994753668,
+          -0.08887500224596279,
+          -0.09154125231334168,
+          -0.09428748988274194,
+          -0.0971161145792242,
+          -0.10002959801660093,
+          -0.10303048595709895,
+          -0.10612140053581191,
+          -0.10930504255188629,
+          -0.11258419382844288,
+          -0.11596171964329616,
+          -0.11944057123259505,
+          -0.12302378836957291,
+          -0.12671450202066012,
+          -0.1305159370812799,
+          0.022114671106632556,
+          0.022778111239831533,
+          0.02346145457702648,
+          0.024165298214337275,
+          0.024890257160767395,
+          0.025636964875590414,
+          0.02640607382185813,
+          0.027198256036513876,
+          0.028014203717609293,
+          0.02885462982913757,
+          0.0297202687240117,
+          0.03061187678573205,
+          0.03153023308930401,
+          0.032476140081983136,
+          0.03345042428444263,
+          0.03445393701297591,
+          0.03548755512336519,
+          0.036552181777066144,
+          0.03764874723037813,
+          0.03877820964728947,
+          0.03994155593670816,
+          0.04113980261480941,
+          0.04237399669325369,
+          0.0436452165940513,
+          0.04495457309187284,
+          0.046303210284629026,
+          0.0476923065931679,
+          0.04912307579096294,
+          0.05059676806469183
+         ]
+        }
+       ],
+       "layout": {
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Weights of columns"
+        },
+        "xaxis": {
+         "title": {
+          "text": "columns"
+         }
+        },
+        "yaxis": {
+         "title": {
+          "text": "weights"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "None"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>GeoFIPS</th>\n",
+       "      <th>GeoName</th>\n",
+       "      <th>2001</th>\n",
+       "      <th>2002</th>\n",
+       "      <th>2003</th>\n",
+       "      <th>2004</th>\n",
+       "      <th>2005</th>\n",
+       "      <th>2006</th>\n",
+       "      <th>2007</th>\n",
+       "      <th>2008</th>\n",
+       "      <th>...</th>\n",
+       "      <th>2014_population</th>\n",
+       "      <th>2015_population</th>\n",
+       "      <th>2016_population</th>\n",
+       "      <th>2017_population</th>\n",
+       "      <th>2018_population</th>\n",
+       "      <th>2019_population</th>\n",
+       "      <th>2020_population</th>\n",
+       "      <th>2021_population</th>\n",
+       "      <th>distance to 1007</th>\n",
+       "      <th>percentile</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1007</td>\n",
+       "      <td>Bibb, AL</td>\n",
+       "      <td>80.443</td>\n",
+       "      <td>81.527</td>\n",
+       "      <td>85.124</td>\n",
+       "      <td>89.317</td>\n",
+       "      <td>88.782</td>\n",
+       "      <td>89.597</td>\n",
+       "      <td>95.308</td>\n",
+       "      <td>94.745</td>\n",
+       "      <td>...</td>\n",
+       "      <td>22586.0</td>\n",
+       "      <td>22607.0</td>\n",
+       "      <td>22654.0</td>\n",
+       "      <td>22606.0</td>\n",
+       "      <td>22383.0</td>\n",
+       "      <td>22405.0</td>\n",
+       "      <td>22223.0</td>\n",
+       "      <td>22477.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>47.86</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>48109</td>\n",
+       "      <td>Culberson, TX</td>\n",
+       "      <td>35.264</td>\n",
+       "      <td>37.743</td>\n",
+       "      <td>36.255</td>\n",
+       "      <td>38.339</td>\n",
+       "      <td>40.177</td>\n",
+       "      <td>41.247</td>\n",
+       "      <td>42.368</td>\n",
+       "      <td>53.349</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2301.0</td>\n",
+       "      <td>2275.0</td>\n",
+       "      <td>2244.0</td>\n",
+       "      <td>2259.0</td>\n",
+       "      <td>2212.0</td>\n",
+       "      <td>2186.0</td>\n",
+       "      <td>2193.0</td>\n",
+       "      <td>2193.0</td>\n",
+       "      <td>1.947278</td>\n",
+       "      <td>99.97</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>48389</td>\n",
+       "      <td>Reeves, TX</td>\n",
+       "      <td>46.003</td>\n",
+       "      <td>49.290</td>\n",
+       "      <td>44.960</td>\n",
+       "      <td>41.682</td>\n",
+       "      <td>39.742</td>\n",
+       "      <td>41.332</td>\n",
+       "      <td>41.009</td>\n",
+       "      <td>41.389</td>\n",
+       "      <td>...</td>\n",
+       "      <td>14614.0</td>\n",
+       "      <td>14936.0</td>\n",
+       "      <td>14484.0</td>\n",
+       "      <td>14314.0</td>\n",
+       "      <td>14526.0</td>\n",
+       "      <td>14847.0</td>\n",
+       "      <td>14730.0</td>\n",
+       "      <td>14487.0</td>\n",
+       "      <td>1.968913</td>\n",
+       "      <td>99.90</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>48283</td>\n",
+       "      <td>La Salle, TX</td>\n",
+       "      <td>6.638</td>\n",
+       "      <td>6.679</td>\n",
+       "      <td>7.065</td>\n",
+       "      <td>6.727</td>\n",
+       "      <td>7.541</td>\n",
+       "      <td>8.729</td>\n",
+       "      <td>8.254</td>\n",
+       "      <td>7.900</td>\n",
+       "      <td>...</td>\n",
+       "      <td>7115.0</td>\n",
+       "      <td>7175.0</td>\n",
+       "      <td>7057.0</td>\n",
+       "      <td>6916.0</td>\n",
+       "      <td>6808.0</td>\n",
+       "      <td>6763.0</td>\n",
+       "      <td>6642.0</td>\n",
+       "      <td>6670.0</td>\n",
+       "      <td>2.070731</td>\n",
+       "      <td>96.40</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>48255</td>\n",
+       "      <td>Karnes, TX</td>\n",
+       "      <td>6.498</td>\n",
+       "      <td>6.891</td>\n",
+       "      <td>7.331</td>\n",
+       "      <td>6.759</td>\n",
+       "      <td>6.537</td>\n",
+       "      <td>6.290</td>\n",
+       "      <td>6.662</td>\n",
+       "      <td>6.937</td>\n",
+       "      <td>...</td>\n",
+       "      <td>14569.0</td>\n",
+       "      <td>14976.0</td>\n",
+       "      <td>14997.0</td>\n",
+       "      <td>14990.0</td>\n",
+       "      <td>15028.0</td>\n",
+       "      <td>14605.0</td>\n",
+       "      <td>14721.0</td>\n",
+       "      <td>14754.0</td>\n",
+       "      <td>2.076390</td>\n",
+       "      <td>98.60</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3077</th>\n",
+       "      <td>6073</td>\n",
+       "      <td>San Diego, CA</td>\n",
+       "      <td>79.703</td>\n",
+       "      <td>83.170</td>\n",
+       "      <td>87.449</td>\n",
+       "      <td>92.400</td>\n",
+       "      <td>97.137</td>\n",
+       "      <td>99.354</td>\n",
+       "      <td>100.938</td>\n",
+       "      <td>100.267</td>\n",
+       "      <td>...</td>\n",
+       "      <td>3234658.0</td>\n",
+       "      <td>3262566.0</td>\n",
+       "      <td>3283586.0</td>\n",
+       "      <td>3293575.0</td>\n",
+       "      <td>3303463.0</td>\n",
+       "      <td>3297959.0</td>\n",
+       "      <td>3297252.0</td>\n",
+       "      <td>3286069.0</td>\n",
+       "      <td>2.924300</td>\n",
+       "      <td>80.21</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3078</th>\n",
+       "      <td>4013</td>\n",
+       "      <td>Maricopa, AZ</td>\n",
+       "      <td>77.463</td>\n",
+       "      <td>80.415</td>\n",
+       "      <td>85.793</td>\n",
+       "      <td>90.349</td>\n",
+       "      <td>97.615</td>\n",
+       "      <td>102.729</td>\n",
+       "      <td>105.313</td>\n",
+       "      <td>103.632</td>\n",
+       "      <td>...</td>\n",
+       "      <td>4040171.0</td>\n",
+       "      <td>4105747.0</td>\n",
+       "      <td>4174844.0</td>\n",
+       "      <td>4231511.0</td>\n",
+       "      <td>4292576.0</td>\n",
+       "      <td>4363816.0</td>\n",
+       "      <td>4438342.0</td>\n",
+       "      <td>4496588.0</td>\n",
+       "      <td>2.950617</td>\n",
+       "      <td>87.18</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3079</th>\n",
+       "      <td>48201</td>\n",
+       "      <td>Harris, TX</td>\n",
+       "      <td>73.137</td>\n",
+       "      <td>72.696</td>\n",
+       "      <td>72.847</td>\n",
+       "      <td>79.658</td>\n",
+       "      <td>80.626</td>\n",
+       "      <td>87.278</td>\n",
+       "      <td>94.310</td>\n",
+       "      <td>91.961</td>\n",
+       "      <td>...</td>\n",
+       "      <td>4452976.0</td>\n",
+       "      <td>4553991.0</td>\n",
+       "      <td>4619635.0</td>\n",
+       "      <td>4651955.0</td>\n",
+       "      <td>4672445.0</td>\n",
+       "      <td>4704042.0</td>\n",
+       "      <td>4732491.0</td>\n",
+       "      <td>4728030.0</td>\n",
+       "      <td>2.952810</td>\n",
+       "      <td>51.14</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3080</th>\n",
+       "      <td>17031</td>\n",
+       "      <td>Cook, IL</td>\n",
+       "      <td>95.406</td>\n",
+       "      <td>94.886</td>\n",
+       "      <td>95.455</td>\n",
+       "      <td>97.260</td>\n",
+       "      <td>99.315</td>\n",
+       "      <td>101.320</td>\n",
+       "      <td>101.826</td>\n",
+       "      <td>99.238</td>\n",
+       "      <td>...</td>\n",
+       "      <td>5320233.0</td>\n",
+       "      <td>5324961.0</td>\n",
+       "      <td>5320293.0</td>\n",
+       "      <td>5311621.0</td>\n",
+       "      <td>5297956.0</td>\n",
+       "      <td>5287099.0</td>\n",
+       "      <td>5262741.0</td>\n",
+       "      <td>5173146.0</td>\n",
+       "      <td>3.019405</td>\n",
+       "      <td>52.43</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3081</th>\n",
+       "      <td>6037</td>\n",
+       "      <td>Los Angeles, CA</td>\n",
+       "      <td>82.070</td>\n",
+       "      <td>83.658</td>\n",
+       "      <td>86.614</td>\n",
+       "      <td>89.137</td>\n",
+       "      <td>91.163</td>\n",
+       "      <td>94.942</td>\n",
+       "      <td>96.400</td>\n",
+       "      <td>98.804</td>\n",
+       "      <td>...</td>\n",
+       "      <td>10051511.0</td>\n",
+       "      <td>10099677.0</td>\n",
+       "      <td>10121673.0</td>\n",
+       "      <td>10123521.0</td>\n",
+       "      <td>10096986.0</td>\n",
+       "      <td>10051154.0</td>\n",
+       "      <td>9989165.0</td>\n",
+       "      <td>9829544.0</td>\n",
+       "      <td>3.256690</td>\n",
+       "      <td>77.03</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>3082 rows × 53 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      GeoFIPS          GeoName    2001    2002    2003    2004    2005  \\\n",
+       "0        1007         Bibb, AL  80.443  81.527  85.124  89.317  88.782   \n",
+       "1       48109    Culberson, TX  35.264  37.743  36.255  38.339  40.177   \n",
+       "2       48389       Reeves, TX  46.003  49.290  44.960  41.682  39.742   \n",
+       "3       48283     La Salle, TX   6.638   6.679   7.065   6.727   7.541   \n",
+       "4       48255       Karnes, TX   6.498   6.891   7.331   6.759   6.537   \n",
+       "...       ...              ...     ...     ...     ...     ...     ...   \n",
+       "3077     6073    San Diego, CA  79.703  83.170  87.449  92.400  97.137   \n",
+       "3078     4013     Maricopa, AZ  77.463  80.415  85.793  90.349  97.615   \n",
+       "3079    48201       Harris, TX  73.137  72.696  72.847  79.658  80.626   \n",
+       "3080    17031         Cook, IL  95.406  94.886  95.455  97.260  99.315   \n",
+       "3081     6037  Los Angeles, CA  82.070  83.658  86.614  89.137  91.163   \n",
+       "\n",
+       "         2006     2007     2008  ...  2014_population  2015_population  \\\n",
+       "0      89.597   95.308   94.745  ...          22586.0          22607.0   \n",
+       "1      41.247   42.368   53.349  ...           2301.0           2275.0   \n",
+       "2      41.332   41.009   41.389  ...          14614.0          14936.0   \n",
+       "3       8.729    8.254    7.900  ...           7115.0           7175.0   \n",
+       "4       6.290    6.662    6.937  ...          14569.0          14976.0   \n",
+       "...       ...      ...      ...  ...              ...              ...   \n",
+       "3077   99.354  100.938  100.267  ...        3234658.0        3262566.0   \n",
+       "3078  102.729  105.313  103.632  ...        4040171.0        4105747.0   \n",
+       "3079   87.278   94.310   91.961  ...        4452976.0        4553991.0   \n",
+       "3080  101.320  101.826   99.238  ...        5320233.0        5324961.0   \n",
+       "3081   94.942   96.400   98.804  ...       10051511.0       10099677.0   \n",
+       "\n",
+       "      2016_population  2017_population  2018_population  2019_population  \\\n",
+       "0             22654.0          22606.0          22383.0          22405.0   \n",
+       "1              2244.0           2259.0           2212.0           2186.0   \n",
+       "2             14484.0          14314.0          14526.0          14847.0   \n",
+       "3              7057.0           6916.0           6808.0           6763.0   \n",
+       "4             14997.0          14990.0          15028.0          14605.0   \n",
+       "...               ...              ...              ...              ...   \n",
+       "3077        3283586.0        3293575.0        3303463.0        3297959.0   \n",
+       "3078        4174844.0        4231511.0        4292576.0        4363816.0   \n",
+       "3079        4619635.0        4651955.0        4672445.0        4704042.0   \n",
+       "3080        5320293.0        5311621.0        5297956.0        5287099.0   \n",
+       "3081       10121673.0       10123521.0       10096986.0       10051154.0   \n",
+       "\n",
+       "      2020_population  2021_population  distance to 1007  percentile  \n",
+       "0             22223.0          22477.0          0.000000       47.86  \n",
+       "1              2193.0           2193.0          1.947278       99.97  \n",
+       "2             14730.0          14487.0          1.968913       99.90  \n",
+       "3              6642.0           6670.0          2.070731       96.40  \n",
+       "4             14721.0          14754.0          2.076390       98.60  \n",
+       "...               ...              ...               ...         ...  \n",
+       "3077        3297252.0        3286069.0          2.924300       80.21  \n",
+       "3078        4438342.0        4496588.0          2.950617       87.18  \n",
+       "3079        4732491.0        4728030.0          2.952810       51.14  \n",
+       "3080        5262741.0        5173146.0          3.019405       52.43  \n",
+       "3081        9989165.0        9829544.0          3.256690       77.03  \n",
+       "\n",
+       "[3082 rows x 53 columns]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# the other queries still work\n",
+    "\n",
+    "f  = FipsQuery(1007, outcome_var = \"gdp\",\n",
+    "               feature_groups_with_weights= {\"gdp\": -2, \"population\":1}, #with one feature group only\n",
+    "               # weights 1-4 won't make a difference\n",
+    "               lag = 0, top =5, time_decay = 1.03)\n",
+    "f.find_euclidean_kins()\n",
+    "display(f.plot_weights())\n",
+    "display(f.euclidean_kins)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['spending_transportation', 'urbanization', 'spending_HHS', 'population', 'spending_commerce', 'industry', 'ethnic_composition', 'transport', 'gdp']\n",
+      "population\n",
+      "True\n"
+     ]
+    },
+    {
+     "ename": "KeyError",
+     "evalue": "'GeoFIPS'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "File \u001b[0;32m~/.local/lib/python3.10/site-packages/pandas/core/indexes/base.py:3803\u001b[0m, in \u001b[0;36mIndex.get_loc\u001b[0;34m(self, key, method, tolerance)\u001b[0m\n\u001b[1;32m   3802\u001b[0m \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m-> 3803\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_engine\u001b[39m.\u001b[39;49mget_loc(casted_key)\n\u001b[1;32m   3804\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mKeyError\u001b[39;00m \u001b[39mas\u001b[39;00m err:\n",
+      "File \u001b[0;32m~/.local/lib/python3.10/site-packages/pandas/_libs/index.pyx:138\u001b[0m, in \u001b[0;36mpandas._libs.index.IndexEngine.get_loc\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32m~/.local/lib/python3.10/site-packages/pandas/_libs/index.pyx:165\u001b[0m, in \u001b[0;36mpandas._libs.index.IndexEngine.get_loc\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32mpandas/_libs/hashtable_class_helper.pxi:5745\u001b[0m, in \u001b[0;36mpandas._libs.hashtable.PyObjectHashTable.get_item\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32mpandas/_libs/hashtable_class_helper.pxi:5753\u001b[0m, in \u001b[0;36mpandas._libs.hashtable.PyObjectHashTable.get_item\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;31mKeyError\u001b[0m: 'GeoFIPS'",
+      "\nThe above exception was the direct cause of the following exception:\n",
+      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "\u001b[1;32m/home/rafal/L2projects/cities/docs/guides/similarity_demo.ipynb Cell 3\u001b[0m line \u001b[0;36m4\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/rafal/L2projects/cities/docs/guides/similarity_demo.ipynb#W1sZmlsZQ%3D%3D?line=1'>2</a>\u001b[0m \u001b[39mprint\u001b[39m(list_available_features())\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/rafal/L2projects/cities/docs/guides/similarity_demo.ipynb#W1sZmlsZQ%3D%3D?line=2'>3</a>\u001b[0m f  \u001b[39m=\u001b[39m FipsQuery(\u001b[39m42001\u001b[39m, feature_groups_with_weights\u001b[39m=\u001b[39m {\u001b[39m\"\u001b[39m\u001b[39mpopulation\u001b[39m\u001b[39m\"\u001b[39m:\u001b[39m4\u001b[39m, \u001b[39m\"\u001b[39m\u001b[39mspending_HHS\u001b[39m\u001b[39m\"\u001b[39m: \u001b[39m3\u001b[39m})\n\u001b[0;32m----> <a href='vscode-notebook-cell:/home/rafal/L2projects/cities/docs/guides/similarity_demo.ipynb#W1sZmlsZQ%3D%3D?line=3'>4</a>\u001b[0m f\u001b[39m.\u001b[39;49mfind_euclidean_kins()\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/rafal/L2projects/cities/docs/guides/similarity_demo.ipynb#W1sZmlsZQ%3D%3D?line=4'>5</a>\u001b[0m \u001b[39m#display(f.plot_weights())\u001b[39;00m\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/rafal/L2projects/cities/docs/guides/similarity_demo.ipynb#W1sZmlsZQ%3D%3D?line=5'>6</a>\u001b[0m \u001b[39m#display(f.euclidean_kins)\u001b[39;00m\n",
+      "File \u001b[0;32m~/L2projects/cities/cities/queries/fips_query.py:256\u001b[0m, in \u001b[0;36mFipsQuery.find_euclidean_kins\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    251\u001b[0m _extracted_my_df \u001b[39m=\u001b[39m _extracted_df[_extracted_df[\u001b[39m\"\u001b[39m\u001b[39mGeoFIPS\u001b[39m\u001b[39m\"\u001b[39m] \u001b[39m==\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mfips]\n\u001b[1;32m    252\u001b[0m _extracted_other_df \u001b[39m=\u001b[39m _extracted_df[_extracted_df[\u001b[39m\"\u001b[39m\u001b[39mGeoFIPS\u001b[39m\u001b[39m\"\u001b[39m] \u001b[39m!=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mfips]\n\u001b[1;32m    255\u001b[0m \u001b[39massert\u001b[39;00m (\n\u001b[0;32m--> 256\u001b[0m         \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mother_df[\u001b[39m\"\u001b[39;49m\u001b[39mGeoFIPS\u001b[39;49m\u001b[39m\"\u001b[39;49m]\u001b[39m.\u001b[39munique() \u001b[39m==\u001b[39m _extracted_other_df[\u001b[39m\"\u001b[39m\u001b[39mGeoFIPS\u001b[39m\u001b[39m\"\u001b[39m]\u001b[39m.\u001b[39munique())\u001b[39m.\u001b[39mall(), \u001b[39m\"\u001b[39m\u001b[39mFIPS are missing\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m    258\u001b[0m \u001b[39massert\u001b[39;00m (\n\u001b[1;32m    259\u001b[0m         \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mother_df[\u001b[39m\"\u001b[39m\u001b[39mGeoFIPS\u001b[39m\u001b[39m\"\u001b[39m] \u001b[39m==\u001b[39m _extracted_other_df[\u001b[39m\"\u001b[39m\u001b[39mGeoFIPS\u001b[39m\u001b[39m\"\u001b[39m]\n\u001b[1;32m    260\u001b[0m     )\u001b[39m.\u001b[39mall(), \u001b[39m\"\u001b[39m\u001b[39mFIPS are misaligned\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m    262\u001b[0m _extracted_other_df\u001b[39m.\u001b[39mcolumns \u001b[39m=\u001b[39m [\n\u001b[1;32m    263\u001b[0m     \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39m{\u001b[39;00mcol\u001b[39m}\u001b[39;00m\u001b[39m_\u001b[39m\u001b[39m{\u001b[39;00mfeature\u001b[39m}\u001b[39;00m\u001b[39m\"\u001b[39m \u001b[39mif\u001b[39;00m col \u001b[39mnot\u001b[39;00m \u001b[39min\u001b[39;00m [\u001b[39m\"\u001b[39m\u001b[39mGeoFIPS\u001b[39m\u001b[39m\"\u001b[39m, \u001b[39m\"\u001b[39m\u001b[39mGeoName\u001b[39m\u001b[39m\"\u001b[39m] \u001b[39melse\u001b[39;00m col\n\u001b[1;32m    264\u001b[0m     \u001b[39mfor\u001b[39;00m col \u001b[39min\u001b[39;00m _extracted_other_df\u001b[39m.\u001b[39mcolumns\n\u001b[1;32m    265\u001b[0m ]\n",
+      "File \u001b[0;32m~/.local/lib/python3.10/site-packages/pandas/core/frame.py:3805\u001b[0m, in \u001b[0;36mDataFrame.__getitem__\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m   3803\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mcolumns\u001b[39m.\u001b[39mnlevels \u001b[39m>\u001b[39m \u001b[39m1\u001b[39m:\n\u001b[1;32m   3804\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_getitem_multilevel(key)\n\u001b[0;32m-> 3805\u001b[0m indexer \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mcolumns\u001b[39m.\u001b[39;49mget_loc(key)\n\u001b[1;32m   3806\u001b[0m \u001b[39mif\u001b[39;00m is_integer(indexer):\n\u001b[1;32m   3807\u001b[0m     indexer \u001b[39m=\u001b[39m [indexer]\n",
+      "File \u001b[0;32m~/.local/lib/python3.10/site-packages/pandas/core/indexes/base.py:3805\u001b[0m, in \u001b[0;36mIndex.get_loc\u001b[0;34m(self, key, method, tolerance)\u001b[0m\n\u001b[1;32m   3803\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_engine\u001b[39m.\u001b[39mget_loc(casted_key)\n\u001b[1;32m   3804\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mKeyError\u001b[39;00m \u001b[39mas\u001b[39;00m err:\n\u001b[0;32m-> 3805\u001b[0m     \u001b[39mraise\u001b[39;00m \u001b[39mKeyError\u001b[39;00m(key) \u001b[39mfrom\u001b[39;00m \u001b[39merr\u001b[39;00m\n\u001b[1;32m   3806\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mTypeError\u001b[39;00m:\n\u001b[1;32m   3807\u001b[0m     \u001b[39m# If we have a listlike key, _check_indexing_error will raise\u001b[39;00m\n\u001b[1;32m   3808\u001b[0m     \u001b[39m#  InvalidIndexError. Otherwise we fall through and re-raise\u001b[39;00m\n\u001b[1;32m   3809\u001b[0m     \u001b[39m#  the TypeError.\u001b[39;00m\n\u001b[1;32m   3810\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_check_indexing_error(key)\n",
+      "\u001b[0;31mKeyError\u001b[0m: 'GeoFIPS'"
+     ]
     }
    ],
    "source": [

--- a/tests/test_cleaning_utils.py
+++ b/tests/test_cleaning_utils.py
@@ -4,7 +4,6 @@ import sys
 import numpy as np
 import pandas as pd
 
-import cities
 from cities.utils.cleaning_utils import find_repo_root, standardize_and_scale
 from cities.utils.data_grabber import list_available_features
 

--- a/tests/test_fips_query.py
+++ b/tests/test_fips_query.py
@@ -33,13 +33,13 @@ queries = [
         top=5,
         time_decay=1.03,
     ),
-    # FipsQuery(
-    #     1007,
-    #     feature_groups_with_weights={"gdp": 4, "population": 4},
-    #     lag=0,
-    #     top=5,
-    #     time_decay=1.03,
-    # ),
+    FipsQuery(
+        1007,
+        feature_groups_with_weights={"gdp": 4, "population": 4},
+        lag=0,
+        top=5,
+        time_decay=1.03,
+    ),
     FipsQuery(
         1007,
         outcome_var="gdp",


### PR DESCRIPTION
This PR resolves #47 .

The user can now instantiate FIPS queries without passing any `outcome_var`. They can also pass `outcome_var`, but exclude it from similarity weighting by giving it weight = 0.

See the first few cells of `similarity_demo.ipynb' for examples. 